### PR TITLE
fix(doc) help tag, coc-contents => coc-denite-contents

### DIFF
--- a/doc/coc-denite.txt
+++ b/doc/coc-denite.txt
@@ -3,7 +3,7 @@
 Author: Qiming Zhao <chemzqm at gmail.com>
 License: MIT license
 
-CONTENTS					*coc-contents*
+CONTENTS					*coc-denite-contents*
 
 Install						|coc-denite-install|
 Denite support 					|coc-denite|


### PR DESCRIPTION
Corrected the help tag contents name, to avoid errors like this:

`
[dein] Error generating helptags:
[dein] Vim(helptags):E154: Duplicate tag "coc-contents" in file /home/jpoppe/.cache/dein/.cache/init.vim/.dein/doc/coc.txt
[dein] function dein#end[1]..dein#util#_end[42]..dein#util#_check_vimrcs[11]..dein#recache_runtimepath[1]..dein#install#_recache_runtimepath[19]..<SNR>20_helptags, line 12
Press ENTER or type command to continue
`